### PR TITLE
Add observation filtering and refactor query logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,14 @@ Make sure to start PostgreSQL before running the server.
     bundle install
    ```
 
+Note: Building tailwind may require BUNDLE_FORCE_RUBY_PLATFORM to be unset, see [https://github.com/flavorjones/tailwindcss-ruby#check-bundle_force_ruby_platform](https://github.com/flavorjones/tailwindcss-ruby#check-bundle_force_ruby_platform).
+
 3. **Database Setup**
 
    ```bash
-     rails db:create
-     rails db:migrate
-     rails db:seed
+     bundle exec rails db:create
+     bundle exec rails db:migrate
+     bundle exec rails db:seed
    ```
 
    > > **Note**: This should only be executed the first time you clone this repository.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   include ApplicationHelper
   include Pagy::Backend
 
-  before_action :current_server, :clear_queries
+  before_action :current_server
 
   def server_present?
     !!current_server

--- a/app/controllers/persistent_states_controller.rb
+++ b/app/controllers/persistent_states_controller.rb
@@ -1,0 +1,12 @@
+class PersistentStatesController < ApplicationController
+  def update_drawer
+    visible = params[:visible]
+
+    if [true, false].include?(visible)
+      session[:queries_visible] = visible
+      head :ok
+    else
+      head :bad_request
+    end
+  end
+end

--- a/app/controllers/transition_of_cares_controller.rb
+++ b/app/controllers/transition_of_cares_controller.rb
@@ -17,9 +17,7 @@ class TransitionOfCaresController < ApplicationController
       composition_data = build_toc_composition(params[:toc])
 
       # Send the composition to the FHIR server
-      response = client.create(composition_data)
-
-      fhir_composition = response.resource
+      fhir_composition = create_resource(composition_data)
 
       if fhir_composition.present?
         # Update the cache with the new composition
@@ -84,8 +82,7 @@ class TransitionOfCaresController < ApplicationController
         fhir_composition.section << section
       end
 
-      response = client.update(fhir_composition, fhir_composition.id)
-      resource = response.resource
+      resource = update_resource(fhir_composition)
 
       if resource.present?
         # Update the cache with the updated composition

--- a/app/helpers/resource_fetch_helper.rb
+++ b/app/helpers/resource_fetch_helper.rb
@@ -34,13 +34,6 @@ module ResourceFetchHelper
     Rails.cache.write(cache_key_for_queries, current_queries)
   end
 
-  private
-
-  def cache_key_for_queries
-    # Uses the session_id helper from CacheKeysHelper
-    "queries-#{session_id}"
-  end
-
   def fetch_resource(resource_class, method:, parameters: {}, id: nil)
     response = case method
                when :search
@@ -215,5 +208,12 @@ module ResourceFetchHelper
     bundle_entries.compact.uniq
   rescue Net::ReadTimeout, Net::OpenTimeout
     raise TIMEOUT_ERROR_MESSAGE
+  end
+
+  private
+
+  def cache_key_for_queries
+    # Uses the session_id helper from CacheKeysHelper
+    "queries-#{session_id}"
   end
 end

--- a/app/helpers/resource_fetch_helper.rb
+++ b/app/helpers/resource_fetch_helper.rb
@@ -106,10 +106,12 @@ module ResourceFetchHelper
   end
 
   def create_resource(fhir_resource)
+    raise ArgumentError, 'Cannot create a nil resource' if fhir_resource.nil?
+
     response = client.create(fhir_resource)
     add_query(response.request)
 
-    unless response.resource.is_a?(fhir_resource.class)
+    if response.code >= 400 || !response.resource.is_a?(fhir_resource.class)
       raise "Error creating #{fhir_resource.class.name}:\n #{response.resource&.inspect}"
     end
 

--- a/app/javascript/controllers/drawer_controller.js
+++ b/app/javascript/controllers/drawer_controller.js
@@ -1,0 +1,40 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="drawer"
+export default class extends Controller {
+  static targets = ["content"]
+  static values = {
+    visible: Boolean
+  }
+
+  visibleValueChanged() {
+    this.updateVisibility()
+  }
+
+  toggle() {
+    this.visibleValue = !this.visibleValue
+    this.updateVisibility()
+    this.persistDrawerState()
+  }
+
+  updateVisibility() {
+    this.contentTarget.classList.toggle("hidden", !this.visibleValue)
+    if (this.visibleValue) {
+      this.dispatch("opened")
+    }
+  }
+
+  persistDrawerState() {
+    const state = { visible: this.visibleValue };
+    const csrfToken = document.querySelector("meta[name='csrf-token']").content;
+
+    fetch('/persistent_states/drawer', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': csrfToken
+      },
+      body: JSON.stringify(state)
+    });
+  }
+}

--- a/app/javascript/controllers/filter_controller.js
+++ b/app/javascript/controllers/filter_controller.js
@@ -1,0 +1,45 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "item", "category", "noResults", "count", "domain"]
+
+  connect() {
+    console.log("Filter controller connected")
+  }
+
+  filter() {
+    const query = this.inputTarget.value.toLowerCase()
+    let visibleItems = 0
+
+    this.itemTargets.forEach((item) => {
+      const code = item.dataset.code || ""
+      const description = item.dataset.description || ""
+      const isVisible = code.toLowerCase().includes(query) || description.toLowerCase().includes(query)
+      item.classList.toggle("hidden", !isVisible)
+      if (isVisible) {
+        visibleItems++
+      }
+    })
+
+    this.categoryTargets.forEach((category) => {
+      const visibleItemsInCategory = category.querySelectorAll('[data-filter-target="item"]:not(.hidden)')
+      const count = visibleItemsInCategory.length
+      const hasVisibleItems = count > 0
+      category.classList.toggle("hidden", !hasVisibleItems)
+
+      const countElement = category.querySelector('[data-filter-target="count"]')
+      if (countElement) {
+        countElement.textContent = `(${count})`
+      }
+    })
+
+    this.domainTargets.forEach((domain) => {
+      const hasVisibleItems = domain.querySelectorAll('[data-filter-target="item"]:not(.hidden)').length > 0
+      domain.classList.toggle("hidden", !hasVisibleItems)
+    })
+
+    if (this.hasNoResultsTarget) {
+      this.noResultsTarget.classList.toggle("hidden", visibleItems > 0)
+    }
+  }
+}

--- a/app/javascript/controllers/filter_controller.js
+++ b/app/javascript/controllers/filter_controller.js
@@ -9,7 +9,7 @@ export default class extends Controller {
 
   filter() {
     const query = this.inputTarget.value.toLowerCase()
-    let visibleItems = 0
+    let hasVisibleItems = false
 
     this.itemTargets.forEach((item) => {
       const code = item.dataset.code || ""
@@ -17,7 +17,7 @@ export default class extends Controller {
       const isVisible = code.toLowerCase().includes(query) || description.toLowerCase().includes(query)
       item.classList.toggle("hidden", !isVisible)
       if (isVisible) {
-        visibleItems++
+        hasVisibleItems = true
       }
     })
 
@@ -39,7 +39,7 @@ export default class extends Controller {
     })
 
     if (this.hasNoResultsTarget) {
-      this.noResultsTarget.classList.toggle("hidden", visibleItems > 0)
+      this.noResultsTarget.classList.toggle("hidden", hasVisibleItems)
     }
   }
 }

--- a/app/javascript/controllers/scroll_to_bottom_controller.js
+++ b/app/javascript/controllers/scroll_to_bottom_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="scroll-to-bottom"
+export default class extends Controller {
+  connect() {
+    this.scroll()
+  }
+
+  scroll() {
+    this.element.scrollTop = this.element.scrollHeight
+  }
+}

--- a/app/views/advance_directives/show.html.erb
+++ b/app/views/advance_directives/show.html.erb
@@ -1,9 +1,6 @@
 <!-- app/views/advance_directives/show.html.erb -->
 <div class="relative w-full max-w-6xl mx-auto px-4 py-6 mb-8 font-sans">
   <%= turbo_frame_tag "adi" do %>
-    <%= turbo_stream.update "queries" do%>
-      <%= render 'shared/queries' %>
-    <% end %>
     <%= turbo_stream.update "flash" do%>
       <%= render 'shared/flash_messages' %>
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -58,7 +58,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   </head>
 
-  <body class="bg-gray-100">
+  <body class="bg-gray-100" data-controller="drawer" data-drawer-visible-value="<%= session.fetch(:queries_visible, true).to_s %>">
     <%= render "shared/header" %>
 
     <% if session[:patient_id].present? %>
@@ -74,6 +74,7 @@
     <main id="patient-content" class="container mx-auto mt-20 px-5 flex flex-col items-center w-full overflow-auto h-full shadow-md">
       <%= yield %>
     </main>
+    <%= render "shared/drawer" %>
   </body>
 
   <!-- Inline JavaScript for Turbo Events -->

--- a/app/views/observations/_observations.html.erb
+++ b/app/views/observations/_observations.html.erb
@@ -6,8 +6,13 @@
         <% index = 0 %>
         <% @grouped_observations.each do |type, sub_group| %>
           <% index += 1 %>
-          <%= render "observations_category", observation_sub_group: sub_group, type: type, index: index %>
+          <div data-filter-target="category">
+            <%= render "observations_category", observation_sub_group: sub_group, type: type, index: index %>
+          </div>
         <% end %>
+        <div data-filter-target="noResults" class="hidden">
+          <h3>No matching observations found.</h3>
+        </div>
       <% end %>
     </div>
     <div class="w-11/12" data-showhide-target="collectionObs">

--- a/app/views/observations/_observations_category.html.erb
+++ b/app/views/observations/_observations_category.html.erb
@@ -2,7 +2,7 @@
   <% body_id = "accordion-body-#{index}"%>
   <h5 id="accordion-heading-<%= index %>">
     <a class="flex items-center justify-between w-full p-5 font-medium text-left text-lg text-gray-500 border border-b-0 border-gray-200 rounded-t-xl focus:ring-4 focus:ring-blue-200 dark:focus:ring-blue-800 dark:border-gray-700 dark:text-gray-400 hover:bg-blue-100 dark:hover:bg-gray-800" data-accordion-target="#<%= body_id %>" aria-expanded="true" aria-controls="<%= body_id %>">
-      <span><%= type %></span>
+      <span><%= type %> <span data-filter-target="count">(<%= observation_sub_group.values.flatten.size %>)</span></span>
       <svg data-accordion-icon class="w-3 h-3 rotate-180 shrink-0" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
         <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5 5 1 1 5"/>
       </svg>

--- a/app/views/observations/_observations_table.html.erb
+++ b/app/views/observations/_observations_table.html.erb
@@ -8,15 +8,21 @@
       <th scope="col" class="px-4 py-3 text-left text-sm">Organization</th>
     </tr>
   </thead>
-  <tbody data-accordion="table-column">
-    <% observations.each do |observation_set| %>
+  <% observations.each do |observation_set| %>
+    <tbody data-accordion="table-column" data-filter-target="domain">
       <tr class="border-t bg-gray-50 border-gray-200">
         <th class="px-4 py-3"> <span class="sr-only">Expand/Collapse Row</span></th>
         <th colspan="4" scope="colgroup" class="py-2 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-3"><%= Observation.format_domain(observation_set.first) %></th>
       </tr>
       <% observation_set.last.each do |observation| %>
         <% identifier = observation.id.to_s.downcase %>
-        <tr class="border-b dark:border-gray-700 hover:bg-gray-200 dark:hover:bg-gray-700 cursor-pointer transition" id="table-column-header-<%= identifier%>" data-accordion-target="#table-column-body-<%= identifier%>" aria-expanded="false" aria-controls="table-column-body-<%= identifier%>">
+        <tr class="border-b dark:border-gray-700 hover:bg-gray-200 dark:hover:bg-gray-700 cursor-pointer transition"
+            id="table-column-header-<%= identifier%>"
+            data-accordion-target="#table-column-body-<%= identifier%>"
+            aria-expanded="false" aria-controls="table-column-body-<%= identifier%>"
+            data-filter-target="item"
+            data-code="<%= observation.code %>"
+            data-description="<%= observation.code %>">
           <td class="p-3 w-4">
             <svg data-accordion-icon="" class="w-6 h-6 shrink-0" fill="currentColor" viewbox="0 0 20 20" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
               <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
@@ -46,6 +52,6 @@
           </td>
         </tr>
       <% end %>
-    <% end %>
-  </tbody>
+    </tbody>
+  <% end %>
 </table>

--- a/app/views/observations/index.html.erb
+++ b/app/views/observations/index.html.erb
@@ -1,5 +1,5 @@
 <!-- app/views/observations/index.html.erb -->
-<div class="xl:mt-6 lg:mt-10 md:mt-12 sm:mt-32 lg:ml-64 w-full lg:w-3/4 h-full" data-controller="showhide">
+<div class="xl:mt-6 lg:mt-10 md:mt-12 sm:mt-32 lg:ml-64 w-full lg:w-3/4 h-full" data-controller="showhide filter">
   <div class="sm:flex sm:items-center w-11/12">
       <div class="sm:flex-auto">
         <h1 class="text-base font-semibold leading-6 text-gray-900">
@@ -27,6 +27,13 @@
           <option>Single Observations</option>
         </select>
       </div>
+    </div>
+    <div data-showhide-target="singleObs" class="w-full md:w-1/3" hidden>
+      <label for="observation-search" class="sr-only">Search</label>
+      <input type="text" name="observation-search" id="observation-search" placeholder="Filter by code or description..."
+             class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500"
+             data-action="input->filter#filter"
+             data-filter-target="input">
     </div>
   </div>
   <%= render "observations" %>

--- a/app/views/shared/_drawer.html.erb
+++ b/app/views/shared/_drawer.html.erb
@@ -1,0 +1,18 @@
+<div data-drawer-target="content" class="hidden fixed bottom-0 left-0 right-0 z-40 w-full p-4 transition-transform bg-white border-t-2 border-gray-200 dark:bg-gray-800 max-h-96 flex flex-col">
+  <div class="flex items-center justify-between mb-4">
+    <h5 class="inline-flex items-center text-base font-semibold text-gray-500 dark:text-gray-400">
+      <svg class="w-4 h-4 me-2.5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 16">
+        <path d="M7 8H4m6 0h3M4 12h3m3 0h6M4 4h12M1 1h18a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1Z"/>
+      </svg>
+      FHIR Queries
+    </h5>
+    <button type="button" data-action="click->drawer#toggle" class="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 inline-flex items-center justify-center dark:hover:bg-gray-600 dark:hover:text-white" >
+      <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
+        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
+      </svg>
+      <span class="sr-only">Close menu</span>
+    </button>
+  </div>
+
+  <%= render 'shared/queries' %>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -59,19 +59,12 @@
               <span class="text-sm text-gray-400 dark:text-gray-400 group-hover:text-blue-600 dark:group-hover:text-blue-500">Patients</span>
             </button>
           </div>
-          <div>
-            <button id="mega-menu-dropdown-button" data-dropdown-toggle="mega-menu-dropdown" class="flex items-center justify-between w-full py-2 px-3 font-medium text-gray-900 border-b border-gray-100 md:w-auto hover:bg-gray-50 md:hover:bg-transparent md:border-0 md:hover:text-blue-600 md:p-0 dark:text-white md:dark:hover:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-blue-500 md:dark:hover:bg-transparent dark:border-gray-700">
-              <span class="text-md text-gray-400 dark:text-gray-400 group-hover:text-blue-600 dark:group-hover:text-blue-500">Queries</span>
-              <svg class="w-2.5 h-2.5 ms-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
-                <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/>
-              </svg>
-            </button>
-            <div id="mega-menu-dropdown" class="absolute z-10 hidden w-auto text-md bg-white border border-gray-100 rounded-lg shadow-md dark:border-gray-700 md:grid-cols-3 dark:bg-gray-700">
-              <div id="queries" class="p-4 pb-0 text-left text-gray-900 md:pb-4 dark:text-white">
-                <%= render 'shared/queries' %>
-              </div>
-            </div>
-          </div>
+          <button type="button" data-action="click->drawer#toggle" class="inline-flex flex-col items-center justify-center px-5 hover:bg-gray-800 dark:hover:bg-gray-800 group">
+            <svg class="w-5 h-5 my-2 text-gray-300 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 16">
+              <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8H4m6 0h3M4 12h3m3 0h6M4 4h12M1 1h18a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1Z"/>
+            </svg>
+            <span class="text-sm text-gray-400 dark:text-gray-400 group-hover:text-blue-600 dark:group-hover:text-blue-500">Queries</span>
+          </button>
 
           <button type="button" class="inline-flex flex-col items-center justify-center px-5 hover:bg-gray-800 dark:hover:bg-gray-800 group"
             data-action="click->menu#navigate" data-url="/disconnect" data-menu-target="item"

--- a/app/views/shared/_queries.html.erb
+++ b/app/views/shared/_queries.html.erb
@@ -1,11 +1,11 @@
-<%= turbo_frame_tag "queries" do %>
-<% if queries.empty? %>
-  <%= 'No query to display'%>
-<% else %>
-  <ol class="mt-4 font-medium max-w-md space-y-1 text-gray-500 list-decimal list-inside dark:text-gray-400">
-    <% queries.each do |query| %>
-      <li><%= query %></li>
-    <% end %>
-  </ol>
-<% end %>
+<%= turbo_frame_tag "queries", class: 'overflow-y-auto max-h-48', data: { controller: 'scroll-to-bottom', action: 'drawer:opened@window->scroll-to-bottom#scroll' } do %>
+  <% if queries.empty? %>
+    <p class="text-gray-500 dark:text-gray-400">'No query to display'</p>
+  <% else %>
+    <ol class="font-medium max-w-full space-y-1 text-gray-500 list-decimal list-inside dark:text-gray-400">
+      <% queries.each do |query| %>
+        <li class="break-all"><%= query %></li>
+      <% end %>
+    </ol>
+  <% end %>
 <% end %>

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -32,6 +32,10 @@ pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
 #
 # workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
+# Run puma in single mode (one worker, no master process) so we can use ActiveSupport::Cache::MemoryStore; if
+# deployment ever needs to be scaled to greater than 1 worker we need another approach for storing queries
+workers 0
+
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
   get '/login', to: 'sessions#login'
   post '/launch', to: 'sessions#launch_server'
   get '/disconnect', to: 'sessions#disconnect_server'
+  patch 'persistent_states/drawer', to: 'persistent_states#update_drawer'
   get 'patients/:patient_id/advance_directives', to: 'advance_directives#index', as: 'patient_advance_directives'
   get 'advance_directives/:id', to: 'advance_directives#show', as: 'advance_directive'
   put 'advance_directives/:id', to: 'advance_directives#update_pmo'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,7 +19,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_24_033040) do
     t.string "name", null: false
     t.string "client_id"
     t.string "client_secret"
-    t.boolean "authenticated_access", default: false
+    t.boolean "authenticated_access", default: false, null: false
     t.string "token_url"
     t.string "authorization_url"
     t.string "scope"

--- a/lib/tasks/fhir_data_pusher.rake
+++ b/lib/tasks/fhir_data_pusher.rake
@@ -238,6 +238,8 @@ namespace :fhir do
   def extract_issue_details(issue)
     if issue['details']
       issue['details']['text'] || 'No details'
+    elsif issue['diagnostics']
+      issue['diagnostics']
     else
       'No details'
     end


### PR DESCRIPTION
This pull request

1. Adds filtering of Observations by code or by text string
2. Refactors the logging of FHIR queries to
    * Keep up to 100 recent queries rather than just showing the queries related to the current request
    * Log updates to FHIR servers in addition to the retrieval requests that were already logged
    * Show the logged FHIR queries in a drawer on the bottom of the page that can be opened and closed (with display state preserved across requests)
3. Makes minor updates to the main project README to improve the initial setup experience for developers
4. Makes a minor change to code that pushes FHIR sample data to a FHIR server to better log errors