### PR TITLE
Add support for showing graphs of observation trends

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,6 +74,9 @@ Layout/LineLength:
 Style/IfUnlessModifier:
   Enabled: false
 
+Style/MultilineBlockChain:
+  Enabled: false
+
 Rails/I18nLocaleTexts:
   Enabled: false
 

--- a/app/javascript/controllers/graph_controller.js
+++ b/app/javascript/controllers/graph_controller.js
@@ -1,0 +1,82 @@
+import { Controller } from "@hotwired/stimulus"
+// TODO: When ApexCharts is managed locally, this should be changed back to:
+// import ApexCharts from "apexcharts"
+import "apexcharts"
+
+// Connects to data-controller="graph"
+export default class extends Controller {
+  static targets = ["modal", "chart"]
+  static values = { url: String }
+
+  connect() {
+    this.chart = null
+  }
+
+  disconnect() {
+    if (this.chart) {
+      this.chart.destroy()
+    }
+  }
+
+  async renderGraph(event) {
+    const ids = event.currentTarget.dataset.ids
+    if (!ids) {
+      console.error("No observation IDs found on the button.")
+      return
+    }
+
+    const url = `${this.urlValue}?ids=${ids}`
+
+    try {
+      const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`)
+      }
+      const graphData = await response.json()
+
+      this.chartTarget.innerHTML = "" // Clear previous chart
+      this.modalTarget.classList.remove("hidden")
+
+      const options = {
+        series: graphData.series,
+        chart: {
+          height: 350,
+          type: 'line',
+        },
+        title: {
+          text: graphData.title,
+          align: 'left'
+        },
+        xaxis: {
+          type: 'datetime',
+        },
+        yaxis: {
+          title: {
+            text: graphData.y_axis_label
+          },
+        },
+        tooltip: {
+          x: {
+            format: 'dd MMM yyyy HH:mm'
+          }
+        }
+      }
+
+      // TODO: When ApexCharts is managed locally, this should be changed back to:
+      // this.chart = new ApexCharts(this.chartTarget, options)
+      this.chart = new window.ApexCharts(this.chartTarget, options)
+      this.chart.render()
+
+    } catch (error) {
+      console.error("Could not fetch or render graph data:", error)
+    }
+  }
+
+  closeModal() {
+    this.modalTarget.classList.add("hidden")
+    if (this.chart) {
+      this.chart.destroy()
+      this.chart = null
+    }
+  }
+}

--- a/app/javascript/controllers/showhide_controller.js
+++ b/app/javascript/controllers/showhide_controller.js
@@ -56,19 +56,15 @@ export default class extends Controller {
   }
 
   toggleObservations() {
-    if (this.obsTypeTarget.value === "Single Observations") {
-      this.singleObsTargets.forEach(el => {
-        el.hidden = false;
-      })
+    const showSingle = this.obsTypeTarget.value === "Single Observations"
+
+    this.singleObsTargets.forEach(el => {
+      el.classList.toggle('hidden', !showSingle)
+    })
+
+    if (this.hasCollectionObsTarget) {
       this.collectionObsTargets.forEach(el => {
-        el.hidden = true;
-      })
-    } else if (this.obsTypeTarget.value === "Observation Collection") {
-      this.singleObsTargets.forEach(el => {
-        el.hidden = true;
-      })
-      this.collectionObsTargets.forEach(el => {
-        el.hidden = false;
+        el.classList.toggle('hidden', showSingle)
       })
     }
   }

--- a/app/views/observations/_observations.html.erb
+++ b/app/views/observations/_observations.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag "observations" do %>
-    <div id="accordion" class="w-11/12" data-accordion="collapse" data-showhide-target="singleObs" hidden>
+    <div id="accordion" class="w-11/12 hidden" data-accordion="collapse" data-showhide-target="singleObs">
       <% if @grouped_observations.blank? %>
         <h3> No Observations Found!</h3>
       <% else %>

--- a/app/views/observations/_observations_table.html.erb
+++ b/app/views/observations/_observations_table.html.erb
@@ -21,8 +21,13 @@
             data-accordion-target="#table-column-body-<%= identifier%>"
             aria-expanded="false" aria-controls="table-column-body-<%= identifier%>"
             data-filter-target="item"
-            data-code="<%= observation.code %>"
-            data-description="<%= observation.code %>">
+            data-id="<%= observation.id %>"
+            data-code="<%= observation.raw_code %>"
+            data-description="<%= observation.code %>"
+            data-status="<%= observation.status %>"
+            data-effective-date-time="<%= observation.effective_date_time %>"
+            data-has-value-quantity="<%= observation.value_quantity? %>"
+            data-has-components="<%= observation.components? %>">
           <td class="p-3 w-4">
             <svg data-accordion-icon="" class="w-6 h-6 shrink-0" fill="currentColor" viewbox="0 0 20 20" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
               <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />

--- a/app/views/observations/index.html.erb
+++ b/app/views/observations/index.html.erb
@@ -1,5 +1,5 @@
 <!-- app/views/observations/index.html.erb -->
-<div class="xl:mt-6 lg:mt-10 md:mt-12 sm:mt-32 lg:ml-64 w-full lg:w-3/4 h-full" data-controller="showhide filter">
+<div class="xl:mt-6 lg:mt-10 md:mt-12 sm:mt-32 lg:ml-64 w-full lg:w-3/4 h-full" data-controller="showhide filter graph" data-graph-url-value="<%= patient_observations_graph_path(@patient.id) %>">
   <div class="sm:flex sm:items-center w-11/12">
       <div class="sm:flex-auto">
         <h1 class="text-base font-semibold leading-6 text-gray-900">
@@ -21,20 +21,55 @@
       <div class="w-full">
         <label for="obs-type" class="sr-only">Filter By type</label>
         <select id="obs-type" class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none dark:text-gray-400 dark:border-gray-700 focus:outline-none focus:ring-0 focus:border-gray-200 peer"
-          data-action="change->showhide#toggleObservations" data-showhide-target="obsType"
+          data-action="change->showhide#toggleObservations change->filter#filter" data-showhide-target="obsType"
         >
           <option>Observation Collection</option>
           <option>Single Observations</option>
         </select>
       </div>
     </div>
-    <div data-showhide-target="singleObs" class="w-full md:w-1/3" hidden>
-      <label for="observation-search" class="sr-only">Search</label>
-      <input type="text" name="observation-search" id="observation-search" placeholder="Filter by code or description..."
-             class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500"
-             data-action="input->filter#filter"
-             data-filter-target="input">
+    <div data-showhide-target="singleObs" class="w-full md:w-1/3 flex items-center space-x-4 hidden">
+      <div class="w-full">
+        <label for="observation-search" class="sr-only">Search</label>
+        <input type="text" name="observation-search" id="observation-search" placeholder="Filter by code or description..."
+               class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500"
+               data-action="input->filter#filter"
+               data-filter-target="input">
+      </div>
+      <button type="button"
+              class="hidden rounded-md bg-indigo-600 px-3 py-2 text-center text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+              data-filter-target="graphButton"
+              data-action="click->graph#renderGraph">
+        Graph
+      </button>
     </div>
   </div>
   <%= render "observations" %>
+
+  <!-- Graph Modal -->
+  <div data-graph-target="modal" class="hidden fixed inset-0 z-50 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+    <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+      <!-- Background overlay -->
+      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+      <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+      <!-- Modal panel -->
+      <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-4xl sm:w-full">
+        <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+          <div class="sm:flex sm:items-start">
+            <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left w-full">
+              <h3 class="text-lg leading-6 font-medium text-gray-900" id="modal-title">Observation Trend</h3>
+              <div class="mt-2">
+                <div data-graph-target="chart"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+          <button type="button" data-action="click->graph#closeModal" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -9,3 +9,4 @@ pin 'flowbite', to: 'https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.5.1/flowb
 pin 'debounce', to: 'https://ga.jspm.io/npm:debounce@1.2.1/index.js'
 pin '@rails/actioncable', to: 'actioncable.esm.js', preload: true
 pin_all_from 'app/javascript/channels', under: 'channels', preload: true
+pin 'apexcharts', to: 'https://cdn.jsdelivr.net/npm/apexcharts@3.49.1/dist/apexcharts.min.js'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ Rails.application.routes.draw do
   get 'patients/:patient_id/nutrition_orders', to: 'nutrition_orders#index', as: 'patient_nutrition_orders'
   get 'patients/:patient_id/service_requests', to: 'service_requests#index', as: 'patient_service_requests'
   get 'patients/:patient_id/observations', to: 'observations#index', as: 'patient_observations'
+  get 'patients/:patient_id/observations/graph', to: 'observations#graph', as: 'patient_observations_graph'
   get 'patients/:patient_id/observations/:id', to: 'observations#show', as: 'patient_observation'
   get 'patients/:patient_id/conditions', to: 'conditions#index', as: 'patient_conditions'
   get 'patients/:patient_id/goals', to: 'goals#index', as: 'patient_goals'


### PR DESCRIPTION
This pull request adds support for showing graphs of observation trends for observations with valueQuantities, either single value observations or observations with multiple components (e.g., blood pressure).

**Testing**

1. Run the pseudo-ehr app locally in dev mode using `./bin/dev`
2. Access the app locally in a browser at http://localhost:3000/
3. Select the MiHIN FHIR server
4. Select the first listed instance of the "Betsy Smith-Johnson" patient
5. In the left column select "Observations"
6. Change the dropdown in the main part of the page from "Observation Collection" to "Single Observations"
7. In the "Filter by code or description" input towards the right enter "8867-4"
8. Click the "Graph" button to show the graph of the heart rate observations
9. Close the graph
10. Change the filter from "8867-4" to the string "blood pressure"
11. Click the "Graph" button to show the graph of the systolic and diastolic blood pressure readings