### PR TITLE
Handle malformed FHIR extension URLs and improve local troubleshooting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -442,6 +442,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-darwin-21
   x86_64-darwin-22
   x86_64-linux

--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ This application can be deployed using Docker Compose for a simple setup.
      ./bin/dev
    ```
 
+   For a local macOS setup that also starts PostgreSQL and prepares the database:
+
+   ```bash
+     scripts/start_pseudo_ehr.sh
+   ```
+
    Open your browser and navigate to `http://localhost:3000`.
 
 2. **Connecting to a FHIR Server**
@@ -388,6 +394,12 @@ This application uses RSpec for testing. You can find tests in the `spec/` folde
 
   ```bash
   ./bin/dev
+  ```
+
+* **Start the app and local dependencies**:
+
+  ```bash
+  scripts/start_pseudo_ehr.sh
   ```
 
 * **Run RSpec tests**:

--- a/app/jobs/convert_qr_to_pfe_and_submit_job.rb
+++ b/app/jobs/convert_qr_to_pfe_and_submit_job.rb
@@ -28,15 +28,30 @@ class ConvertQrToPfeAndSubmitJob < ApplicationJob
 
       task.mark_completed("Task #{task_id}: Conversion completed successfully.")
     else
-      body = begin
-        JSON.parse(response.body)
-      rescue StandardError
-        {}
-      end
-      task.mark_failed("Task #{task_id}: Conversion failed: #{body['error'] || response.status}")
+      task.mark_failed("Task #{task_id}: Conversion failed: #{api_error_message(response)}")
     end
   rescue StandardError => e
     task&.mark_failed("Unexpected error: #{e.message}")
     Rails.logger.error("[QR Conversion Job] #{e.message}")
+  end
+
+  private
+
+  def api_error_message(response)
+    body = JSON.parse(response.body)
+    body['error'].presence ||
+      operation_outcome_message(body['resource']) ||
+      body['code'].presence ||
+      response.status
+  rescue StandardError
+    response.status
+  end
+
+  def operation_outcome_message(resource)
+    return unless resource.is_a?(Hash) && resource['resourceType'] == 'OperationOutcome'
+
+    Array(resource['issue']).filter_map do |issue|
+      issue['diagnostics'].presence || issue.dig('details', 'text').presence
+    end.join('; ').presence
   end
 end

--- a/app/services/fhir_push_service.rb
+++ b/app/services/fhir_push_service.rb
@@ -1,6 +1,7 @@
 require 'net/http'
 require 'uri'
 require 'json'
+require 'openssl'
 
 # TODO: If auth needed refactor this to use client from fhir_client_service.rb
 
@@ -43,6 +44,8 @@ class FhirPushService
       attempt_num = retry_counts[current_url]
 
       begin
+        update_task_status("Fetching #{File.basename(URI.parse(current_url).path)}... (Attempt #{attempt_num}/#{MAX_RETRIES})",
+                           successful_resources.size)
         resource_json = fetch_resource(current_url)
         resource = JSON.parse(resource_json)
         rewrite_questionnaire_references!(resource)
@@ -93,7 +96,24 @@ class FhirPushService
 
   def fetch_resource(url)
     uri = URI(url)
-    Net::HTTP.get(uri)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == 'https'
+    http.open_timeout = HTTP_TIMEOUT
+    http.read_timeout = HTTP_TIMEOUT
+    http.cert_store = certificate_store if http.use_ssl?
+
+    response = http.get(uri.request_uri)
+    response.value
+    response.body
+  end
+
+  def certificate_store
+    store = OpenSSL::X509::Store.new
+    store.set_default_paths
+    # Homebrew OpenSSL can inherit CRL-check flags that require local CRLs for
+    # public web certificates. Keep normal CA verification, but do not require CRLs.
+    store.flags = 0 if store.respond_to?(:flags=)
+    store
   end
 
   def rewrite_questionnaire_references!(resource)

--- a/app/services/sample_data_service.rb
+++ b/app/services/sample_data_service.rb
@@ -1,13 +1,12 @@
 require 'net/http'
 require 'json'
+require 'openssl'
 
 class SampleDataService
   class << self
     def manifest
       Rails.cache.fetch('sample_data_manifest', expires_in: 1.minute) do
-        uri = URI(Rails.configuration.x.sample_data.manifest_url)
-        response = Net::HTTP.get(uri)
-        JSON.parse(response)
+        JSON.parse(fetch_uri(Rails.configuration.x.sample_data.manifest_url))
       end
     rescue StandardError => e
       Rails.logger.error "Failed to fetch or parse manifest.json: #{e.message}"
@@ -39,13 +38,33 @@ class SampleDataService
 
     def fetch_resource(url)
       Rails.cache.fetch("sample_resource_content_#{url}", expires_in: 1.minute) do
-        uri = URI(url)
-        response = Net::HTTP.get(uri)
-        JSON.pretty_generate(JSON.parse(response))
+        JSON.pretty_generate(JSON.parse(fetch_uri(url)))
       end
     rescue StandardError => e
       Rails.logger.error "Failed to fetch or parse resource from #{url}: #{e.message}"
       { error: "Failed to fetch resource: #{e.message}" }.to_json
+    end
+
+    private
+
+    def fetch_uri(url)
+      uri = URI(url)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == 'https'
+      http.cert_store = certificate_store if http.use_ssl?
+
+      response = http.get(uri.request_uri)
+      response.value
+      response.body
+    end
+
+    def certificate_store
+      store = OpenSSL::X509::Store.new
+      store.set_default_paths
+      # Homebrew OpenSSL can inherit CRL-check flags that require local CRLs for
+      # public web certificates. Keep normal CA verification, but do not require CRLs.
+      store.flags = 0 if store.respond_to?(:flags=)
+      store
     end
   end
 end

--- a/config/initializers/fhir_client.rb
+++ b/config/initializers/fhir_client.rb
@@ -1,5 +1,14 @@
 module FHIR
   class Client
+    unless method_defined?(:parse_reply_without_blank_extension_url_sanitizer)
+      alias_method :parse_reply_without_blank_extension_url_sanitizer, :parse_reply
+
+      def parse_reply(klass, format, response)
+        sanitize_fhir_reply!(response, format)
+        parse_reply_without_blank_extension_url_sanitizer(klass, format, response)
+      end
+    end
+
     # Override fetch_patient_record to accept search parameters
     def fetch_patient_record(id = nil, startTime = nil, endTime = nil, method = 'GET', format = nil, search_params: {}) # rubocop:disable Naming/MethodParameterName,Naming/VariableName
       fetch_record(id, [startTime, endTime], method, versioned_resource_class('Patient'), format, search_params) # rubocop:disable Naming/VariableName
@@ -47,6 +56,60 @@ module FHIR
       reply.resource = parse_reply(versioned_resource_class('Bundle'), format, reply)
       reply.resource_class = options[:resource]
       reply
+    end
+
+    private
+
+    def sanitize_fhir_reply!(reply, format)
+      sanitized_body = sanitize_fhir_response_body(reply.body, format)
+      reply.response[:body] = sanitized_body if sanitized_body
+    end
+
+    def sanitize_fhir_response_body(body, format)
+      return body unless json_format?(format) && body.present?
+
+      resource = JSON.parse(body)
+      removed_count = remove_blank_extension_urls!(resource)
+
+      if removed_count.positive?
+        Rails.logger.warn("Removed #{removed_count} FHIR extension(s) with blank url before parsing response")
+        JSON.generate(resource)
+      else
+        body
+      end
+    rescue JSON::ParserError
+      body
+    end
+
+    def json_format?(format)
+      format.to_s.include?('json')
+    end
+
+    def remove_blank_extension_urls!(value)
+      case value
+      when Array
+        value.sum { |item| remove_blank_extension_urls!(item) }
+      when Hash
+        removed_count = 0
+
+        %w[extension modifierExtension].each do |extension_key|
+          next unless value[extension_key].is_a?(Array)
+
+          value[extension_key].each { |extension| removed_count += remove_blank_extension_urls!(extension) }
+          original_size = value[extension_key].size
+          value[extension_key].reject! { |extension| extension.is_a?(Hash) && blank_extension_url?(extension['url']) }
+          removed_count += original_size - value[extension_key].size
+        end
+
+        value.each_value { |child| removed_count += remove_blank_extension_urls!(child) }
+        removed_count
+      else
+        0
+      end
+    end
+
+    def blank_extension_url?(url)
+      url.nil? || url.to_s.strip.empty?
     end
   end
 end

--- a/scripts/start_pseudo_ehr.sh
+++ b/scripts/start_pseudo_ehr.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+POSTGRES_DATA_DIR="${POSTGRES_DATA_DIR:-/opt/homebrew/var/postgresql@14}"
+PGHOST="${PGHOST:-127.0.0.1}"
+PGPORT="${PGPORT:-5432}"
+REQUIRED_BUNDLER_VERSION="${REQUIRED_BUNDLER_VERSION:-2.4.12}"
+SKIP_INSTALL=false
+
+log() {
+  printf '\n==> %s\n' "$*"
+}
+
+fail() {
+  printf '\nERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<USAGE
+Usage: scripts/start_pseudo_ehr.sh [options]
+
+Set up the local PseudoEHR environment, start PostgreSQL, prepare the Rails
+database, and launch the app with ./bin/dev.
+
+Options:
+  --skip-install   Do not install missing Bundler, gems, or JavaScript packages
+  -h, --help       Show this help text
+
+Environment overrides:
+  POSTGRES_DATA_DIR   PostgreSQL data directory (default: /opt/homebrew/var/postgresql@14)
+  PGHOST              PostgreSQL host (default: 127.0.0.1)
+  PGPORT              PostgreSQL port (default: 5432)
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-install)
+      SKIP_INSTALL=true
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "Unknown option: $1"
+      ;;
+  esac
+  shift
+done
+
+find_rbenv() {
+  if command -v rbenv >/dev/null 2>&1; then
+    command -v rbenv
+  elif [[ -x /opt/homebrew/bin/rbenv ]]; then
+    printf '%s\n' /opt/homebrew/bin/rbenv
+  elif [[ -x "$HOME/.rbenv/bin/rbenv" ]]; then
+    printf '%s\n' "$HOME/.rbenv/bin/rbenv"
+  fi
+}
+
+wait_for_postgres() {
+  local tries=30
+
+  if ! command -v pg_isready >/dev/null 2>&1; then
+    log "pg_isready not found; skipping PostgreSQL readiness check"
+    return
+  fi
+
+  until pg_isready -q -h "$PGHOST" -p "$PGPORT"; do
+    tries=$((tries - 1))
+    if [[ "$tries" -le 0 ]]; then
+      fail "PostgreSQL did not become ready at $PGHOST:$PGPORT"
+    fi
+    sleep 1
+  done
+}
+
+start_postgres() {
+  if command -v pg_isready >/dev/null 2>&1 && pg_isready -q -h "$PGHOST" -p "$PGPORT"; then
+    log "PostgreSQL is already running at $PGHOST:$PGPORT"
+    return
+  fi
+
+  command -v pg_ctl >/dev/null 2>&1 || fail "pg_ctl was not found. Install/start PostgreSQL, then retry."
+  [[ -d "$POSTGRES_DATA_DIR" ]] || fail "PostgreSQL data directory not found: $POSTGRES_DATA_DIR"
+
+  log "Starting PostgreSQL from $POSTGRES_DATA_DIR"
+  pg_ctl -D "$POSTGRES_DATA_DIR" start
+  wait_for_postgres
+}
+
+cd "$APP_ROOT"
+
+RBENV_BIN="$(find_rbenv || true)"
+if [[ -n "$RBENV_BIN" ]]; then
+  log "Loading rbenv from $RBENV_BIN"
+  RBENV_ROOT="${RBENV_ROOT:-$HOME/.rbenv}"
+  export RBENV_ROOT
+  export PATH="$RBENV_ROOT/shims:$PATH"
+
+  set +e
+  RBENV_INIT="$("$RBENV_BIN" init - bash 2>/dev/null)"
+  RBENV_INIT_STATUS=$?
+  if [[ "$RBENV_INIT_STATUS" -eq 0 && -n "$RBENV_INIT" ]]; then
+    eval "$RBENV_INIT"
+  fi
+  set -e
+fi
+
+if [[ -f .ruby-version ]]; then
+  expected_ruby="$(<.ruby-version)"
+  current_ruby="$(ruby -e 'print RUBY_VERSION')"
+  if [[ "$current_ruby" != "$expected_ruby" ]]; then
+    fail "Ruby $expected_ruby is required, but current Ruby is $current_ruby. Check rbenv setup."
+  fi
+fi
+
+log "Using Ruby $(ruby -e 'print RUBY_VERSION')"
+unset BUNDLE_FORCE_RUBY_PLATFORM
+
+if ! gem list bundler -i -v "$REQUIRED_BUNDLER_VERSION" --silent; then
+  if [[ "$SKIP_INSTALL" == "true" ]]; then
+    fail "Bundler $REQUIRED_BUNDLER_VERSION is not installed. Retry without --skip-install."
+  fi
+
+  log "Installing Bundler $REQUIRED_BUNDLER_VERSION"
+  gem install bundler -v "$REQUIRED_BUNDLER_VERSION"
+fi
+
+log "Checking Ruby gems"
+if ! bundle check; then
+  if [[ "$SKIP_INSTALL" == "true" ]]; then
+    fail "Ruby gems are missing. Retry without --skip-install."
+  fi
+
+  bundle install
+fi
+
+if [[ -f yarn.lock ]]; then
+  command -v yarn >/dev/null 2>&1 || fail "yarn was not found. Install Yarn, then retry."
+  if [[ ! -d node_modules ]]; then
+    if [[ "$SKIP_INSTALL" == "true" ]]; then
+      fail "node_modules is missing. Retry without --skip-install."
+    fi
+
+    log "Installing JavaScript packages"
+    yarn install
+  fi
+fi
+
+export PGHOST
+export PGPORT
+start_postgres
+
+log "Preparing Rails database"
+bundle exec rails db:prepare
+
+log "Starting PseudoEHR at http://localhost:3000"
+exec ./bin/dev

--- a/spec/helpers/resource_fetch_helper_spec.rb
+++ b/spec/helpers/resource_fetch_helper_spec.rb
@@ -107,6 +107,61 @@ RSpec.describe ResourceFetchHelper, type: :helper do
       result = helper.fetch_single_patient_record('123')
       expect(result.first).to be_a(FHIR::Patient)
     end
+
+    it 'removes extensions with blank URLs before parsing patient records' do
+      params = '_count=1000&_include=*&_include:iterate=*&_maxresults=2000&_revinclude=*&_sort=-_lastUpdated'
+      url = "#{fhir_server.base_url}/Patient/123/$everything?#{params}"
+      body = {
+        resourceType: 'Bundle',
+        type: 'searchset',
+        entry: [
+          { resource: { resourceType: 'Patient', id: '123' } },
+          {
+            resource: {
+              resourceType: 'Composition',
+              id: 'composition-123',
+              status: 'final',
+              type: { coding: [{ system: 'http://loinc.org', code: '34133-9' }] },
+              date: '2026-06-23T00:00:00Z',
+              title: 'Test Composition',
+              section: [
+                {
+                  text: {
+                    status: 'generated',
+                    div: '<div xmlns="http://www.w3.org/1999/xhtml">Test</div>',
+                    extension: [
+                      {
+                        url: nil,
+                        extension: [
+                          {
+                            url: 'http://hl7.org/fhir/StructureDefinition/textLink',
+                            extension: [
+                              { url: 'text', valueString: 'Test' },
+                              { url: 'reference', valueReference: { reference: 'Observation/obs-123' } }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+
+      stub_request(:get, url)
+        .to_return(
+          status: 200,
+          body: body.to_json,
+          headers: { 'Content-Type' => 'application/fhir+json' }
+        )
+
+      result = helper.fetch_single_patient_record('123')
+
+      expect(result.map(&:resourceType)).to include('Patient', 'Composition')
+    end
   end
 
   describe '#fetch_resource_with_defaults' do
@@ -137,6 +192,62 @@ RSpec.describe ResourceFetchHelper, type: :helper do
 
       document_reference = helper.fetch_document_reference('doc123')
       expect(document_reference).to be_a(FHIR::DocumentReference)
+    end
+  end
+
+  describe '#fetch_bundle' do
+    it 'removes extensions with blank URLs before parsing a directly fetched bundle' do
+      body = {
+        resourceType: 'Bundle',
+        id: 'bundle-123',
+        type: 'collection',
+        entry: [
+          {
+            resource: {
+              resourceType: 'Composition',
+              id: 'composition-123',
+              status: 'final',
+              type: { coding: [{ system: 'http://loinc.org', code: '42348-3' }] },
+              date: '2026-06-23T00:00:00Z',
+              title: 'ADI Composition',
+              section: [
+                {
+                  text: {
+                    status: 'generated',
+                    div: '<div xmlns="http://www.w3.org/1999/xhtml">ADI</div>',
+                    extension: [
+                      {
+                        url: nil,
+                        extension: [
+                          {
+                            url: 'http://hl7.org/fhir/StructureDefinition/textLink',
+                            extension: [
+                              { url: 'text', valueString: 'ADI' },
+                              { url: 'reference', valueReference: { reference: 'Observation/obs-123' } }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+
+      stub_request(:get, "#{fhir_server.base_url}/Bundle/bundle-123")
+        .to_return(
+          status: 200,
+          body: body.to_json,
+          headers: { 'Content-Type' => 'application/fhir+json' }
+        )
+
+      bundle = helper.fetch_bundle('bundle-123')
+
+      expect(bundle).to be_a(FHIR::Bundle)
+      expect(bundle.entry.map(&:resource).map(&:resourceType)).to include('Composition')
     end
   end
 

--- a/spec/jobs/convert_qr_to_pfe_and_submit_job_spec.rb
+++ b/spec/jobs/convert_qr_to_pfe_and_submit_job_spec.rb
@@ -147,6 +147,43 @@ RSpec.describe ConvertQrToPfeAndSubmitJob, type: :job do
       end
     end
 
+    context 'when conversion fails with an OperationOutcome' do
+      let(:failed_response) do
+        instance_double(
+          Faraday::Response,
+          success?: false,
+          status: 422,
+          body: {
+            'code' => 400,
+            'resource' => {
+              'resourceType' => 'OperationOutcome',
+              'issue' => [
+                {
+                  'severity' => 'error',
+                  'code' => 'processing',
+                  'diagnostics' => 'HAPI-0450: Failed to parse request body as JSON resource'
+                }
+              ]
+            }
+          }.to_json
+        )
+      end
+
+      before do
+        allow(Faraday).to receive(:post).and_yield(req = double).and_return(failed_response)
+        allow(req).to receive(:headers).and_return({})
+        allow(req).to receive(:body=)
+        allow(PatientRecordCache).to receive(:update_patient_record)
+      end
+
+      it 'marks the task as failed with the OperationOutcome diagnostics' do
+        qr_conversion_job.perform(qr_hash, fhir_server_url, task_id, patient_id)
+
+        expect(task_status).to have_received(:mark_failed)
+          .with("Task #{task_id}: Conversion failed: HAPI-0450: Failed to parse request body as JSON resource")
+      end
+    end
+
     context 'when an unexpected exception occurs' do
       before do
         allow(Faraday).to receive(:post).and_raise(StandardError.new('Connection error'))

--- a/spec/services/fhir_push_service_spec.rb
+++ b/spec/services/fhir_push_service_spec.rb
@@ -43,9 +43,11 @@ RSpec.describe FhirPushService, type: :service do
     end
 
     it 'updates task status with progress and completion in order' do
-      # Order: start, push practitioner, push patient, complete
+      # Order: start, fetch/push practitioner, fetch/push patient, complete
       expect(task_status).to receive(:update_status).with('running', a_string_starting_with('[0%] Starting data push...'))
+      expect(task_status).to receive(:update_status).with('running', a_string_matching(%r{\[0%\].*Fetching practitioner1}))
       expect(task_status).to receive(:update_status).with('running', a_string_matching(%r{\[0%\].*Practitioner/practitioner1}))
+      expect(task_status).to receive(:update_status).with('running', a_string_matching(%r{\[50%\].*Fetching patient1}))
       expect(task_status).to receive(:update_status).with('running', a_string_matching(%r{\[50%\].*Patient/patient1}))
       expect(task_status).to receive(:update_status).with('completed', '[100%] Push completed successfully. 2 resources pushed.')
 


### PR DESCRIPTION
This PR includes several fixes that should help other developers load and troubleshoot pseudoEHR data more reliably:

1. Sanitizes incoming FHIR JSON responses by removing extension / modifierExtension entries with blank URLs before fhir_models parses them.
2. Fixes ADI and $everything parsing failures caused by url: null extensions in external FHIR payloads.
3. Improves sample data push reliability by using explicit Net::HTTP timeouts and SSL certificate store handling.
4. Surfaces OperationOutcome diagnostics when QR-to-PFE conversion fails.
5. Adds scripts/start_pseudo_ehr.sh to simplify local startup, including PostgreSQL startup and DB preparation.